### PR TITLE
fix: correct types.ts path from src/libs to src/lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "stripe:listen": "stripe listen --forward-to=localhost:3000/api/webhooks --project-name=default",
-    "generate-types": "npx supabase gen types typescript --project-id vdytepbsknevxtcfzvpp --schema public > src/libs/supabase/types.ts",
+    "generate-types": "npx supabase gen types typescript --project-id vdytepbsknevxtcfzvpp --schema public > src/lib/supabase/types.ts",
     "supabase:link": "env-cmd -f ./.env.local supabase link --project-ref vdytepbsknevxtcfzvpp",
     "migration:new": "supabase migration new",
     "migration:up": "supabase migration up --linked --debug && npm run generate-types",


### PR DESCRIPTION
## Fix Types Generation Path

### Problem
The `generate-types` script in package.json references `src/libs/supabase/types.ts`, but the actual directory structure uses `src/lib/supabase/types.ts`. This causes type generation to fail during setup.

### Solution
- Updated path from `src/libs` to `src/lib` in package.json